### PR TITLE
[FIX] Unit test failure on Github Actions.

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -160,7 +160,7 @@ func (c *RootCLI) loadLog(cc *cobra.Command) (func(), error) {
 		os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
 	if err != nil {
 		log.Error().Err(err).Msg("SetLog.OpenFile.Fail")
-		return func() {}, err
+		return nil, err
 	}
 
 	barton.NewZerologConfig().
@@ -182,7 +182,7 @@ func (c *RootCLI) loadConfig(cc *cobra.Command) (func(), error) {
 			log.Error().
 				Err(err).
 				Msg("ReadInConfig.Preset.Fail")
-			return func() {}, err
+			return nil, err
 		}
 		return func() {}, nil
 	}
@@ -196,7 +196,7 @@ func (c *RootCLI) loadConfig(cc *cobra.Command) (func(), error) {
 			Err(err).
 			Str("config", c.configFile).
 			Msg("ReadConfig.Fail")
-		return func() {}, err
+		return nil, err
 	}
 
 	return func() {}, nil

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -111,14 +111,17 @@ func TestUserConfigDirReturnError(t *testing.T) {
 	home := os.Getenv("HOME")
 	plan9Home := os.Getenv("home")
 	appDir := os.Getenv("AppData")
+	xdgConfigHome := os.Getenv("XDG_CONFIG_HOME")
 	defer os.Setenv("HOME", home)
 	defer os.Setenv("home", plan9Home)
 	defer os.Setenv("AppData", appDir)
+	defer os.Setenv("XDG_CONFIG_HOME", xdgConfigHome)
 
 	// Now, trigger an error
 	os.Setenv("HOME", "")
 	os.Setenv("AppDir", "")
 	os.Setenv("home", "")
+	os.Setenv("XDG_CONFIG_HOME", "") // Github Actions server ues it.
 
 	// A behavior of viper is to convert given relative path to
 	// absolute.


### PR DESCRIPTION
Github Actions seems using XDG_CONFIG_HOME to set path. The current
TestUserConfigDirReturnError unit test relies on logic that we must
remove all environment variables to trigger an error. This is a required
setup to make it work on both my workbox and Github actions.