### PR TITLE
Configuration option to skip reading configuration files.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,7 +2,7 @@ name: Barton CI/CD pipeline
 
 on:
   push:
-    branches: [ main feature/**, bugfix/**, ops/** ]
+    branches: [ main, feature/**, bugfix/**, ops/** ]
   pull_request:
     types: [ closed ]
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -199,6 +199,16 @@ features.
 
 ## Changelog
 
+### v0.4.0 (developing)
+
+* [X] In-code and command line setting to skip config file reading.
+* [ ] Allow binding environment variable on command line.
+* [ ] Integrate OpenTelemetry API to record tracing.
+
+### v0.3.1
+
+* [X] Fix unit test coverage drop shown only on codecov.io.
+
 ### v0.3.0
 
 * [X] Default login sub-command based on github.com/spf13/cobra


### PR DESCRIPTION
   There are two ways to configure config file reading:
    1. In-code - By default config file is skipped until
       SetViperLocalConfig() is called.
    2. In command line - Use --skip-config-file command line options.