### PR TITLE
[NEW] RootCLI flags is not persistent but local flags.

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,9 +201,10 @@ features.
 
 ### v0.4.0 (developing)
 
-* [X] In-code and command line setting to skip config file reading.
-* [ ] Allow binding environment variable on command line.
-* [ ] Integrate OpenTelemetry API to record tracing.
+* [ ] Bind environment variable on root and subcommand.
+* [X] Configuration option to skip reading configuration files.
+* [ ] Server-end send telemetry via OpenTelemetry API.
+* [X] RootCLI uses Flags() to allow subcommands use same shortcut names.
 
 ### v0.3.1
 

--- a/_example/client/config.yml
+++ b/_example/client/config.yml
@@ -1,5 +1,5 @@
 testcli:
   login:
     auth-url: http://127.0.0.1:8080/login
-    token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2MzQ0NjAwMTksIm5hbWUiOiJ0ZXN0dXNlciJ9.OzTgoyYkWpNMUulqW87zI52sV9QanJsQcWGifD2zgmA
+    token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2MzU2NzA4ODAsIm5hbWUiOiJ0ZXN0dXNlciJ9.U36DDe3fEdhj6hYFWnVtyOOKeepZVWZeaRZkELqla68
     username: testuser

--- a/cli/login_test.go
+++ b/cli/login_test.go
@@ -28,6 +28,7 @@ func TestSubConfigCreateDefaultDatablock(t *testing.T) {
 	root := NewRootCLI("test-app").
 		AferoFS(fs).
 		Viper(v).
+		SetLocalViperPolicy().
 		AddSubcommand(login)
 	assert.Equal(t, v, login.v)
 


### PR DESCRIPTION
This is to allow new subcommands use -c / -l / -k shortcut in their
subommands. The RootCLI object does not set its -c -l -k command
line option as global.

Note the behavior may change later.